### PR TITLE
fix: allow more youtube results

### DIFF
--- a/src/commands/search/youtube.ts
+++ b/src/commands/search/youtube.ts
@@ -44,7 +44,7 @@ export class UserCommand extends Command {
 	private query(options: Options) {
 		const url = new URL('https://youtube.googleapis.com/youtube/v3/search');
 		url.searchParams.append('part', 'snippet');
-		url.searchParams.append('safeSearch', 'strict');
+		url.searchParams.append('safeSearch', 'moderate');
 		url.searchParams.append('maxResults', '25');
 		url.searchParams.append('q', options.query);
 		url.searchParams.append('key', envParseString('GOOGLE_API_TOKEN'));


### PR DESCRIPTION
This allows for more YouTube search results to be returned. In general the moderate (actually also default, we can omit it entirely if you prefer that) is good enough, even searching something that on the website easily returns partially or fully nude women doesn't do so through the API. 

Refer to https://discord.com/channels/737141877803057244/1049420722566594602/1079499365409894501 (Sapphire, #Gaming, message from reds mentioning me about safe search) for more information.