### PR TITLE
fix(manage-tag): increase limits and various fixes

### DIFF
--- a/src/commands/tags/manage-tag.ts
+++ b/src/commands/tags/manage-tag.ts
@@ -69,7 +69,6 @@ export class UserCommand extends Command {
 				new TextInputBuilder()
 					.setCustomId('content')
 					.setLabel(t(LanguageKeys.Commands.ManageTag.ModalContent))
-					.setMaxLength(MaximumContentLength)
 					.setRequired(true)
 					.setStyle(TextInputStyle.Paragraph)
 			);
@@ -149,7 +148,6 @@ export class UserCommand extends Command {
 				new TextInputBuilder()
 					.setCustomId('content')
 					.setLabel(t(LanguageKeys.Commands.ManageTag.ModalContent))
-					.setMaxLength(MaximumContentLength)
 					.setRequired(true)
 					.setStyle(TextInputStyle.Paragraph)
 					.setValue(existing.content)
@@ -157,7 +155,7 @@ export class UserCommand extends Command {
 			return interaction.showModal({
 				title: t(LanguageKeys.Commands.ManageTag.Modal),
 				components: [row.toJSON()],
-				custom_id: `tag.edit.${embed ? 1 : 0}.${embedColor}.${name}.${nextName}`
+				custom_id: `tag.edit.${embed ? 1 : 0}.${embedColor}.${existing.name}.${nextName}`
 			});
 		}
 

--- a/src/commands/tags/manage-tag.ts
+++ b/src/commands/tags/manage-tag.ts
@@ -11,6 +11,22 @@ import { applyLocalizedBuilder, getSupportedUserLanguageT, resolveUserKey, type 
 import { isAbortError } from '@skyra/safe-fetch';
 import { MessageFlags, PermissionFlagsBits, TextInputStyle } from 'discord-api-types/v10';
 
+/**
+ * The content's max length is set to 4096, which is exactly 2048 * 2, however, we still set limits internally:
+ * - ≤2048 (embed: true)
+ * - ≤2000 (embed: false)
+ *
+ * Said limits are measured in code points, not characters, matching the checks the Discord API does. For reference:
+ * - 'a'.repeat(2000);
+ *   str.length     : 2000
+ *   [...str].length: 2000
+ *
+ * - '🔥'.repeat(2000);
+ *   str.length     : 4000
+ *   [...str].length: 2000
+ */
+const MaximumContentLength = 4096;
+
 @RegisterCommand((builder) =>
 	applyLocalizedBuilder(builder, LanguageKeys.Commands.ManageTag.RootName, LanguageKeys.Commands.ManageTag.RootDescription)
 		.setDMPermission(false)
@@ -291,22 +307,6 @@ function makeNameOption() {
 function makeNewNameOption() {
 	return applyLocalizedBuilder(new SlashCommandStringOption(), LanguageKeys.Commands.ManageTag.OptionsNewName).setMaxLength(32);
 }
-
-/**
- * The content's max length is set to 4096, which is exactly 2048 * 2, however, we still set limits internally:
- * - ≤2048 (embed: true)
- * - ≤2000 (embed: false)
- *
- * Said limits are measured in code points, not characters, matching the checks the Discord API does. For reference:
- * - 'a'.repeat(2000);
- *   str.length     : 2000
- *   [...str].length: 2000
- *
- * - '🔥'.repeat(2000);
- *   str.length     : 4000
- *   [...str].length: 2000
- */
-const MaximumContentLength = 4096;
 
 function makeContentOption() {
 	return applyLocalizedBuilder(new SlashCommandStringOption(), LanguageKeys.Commands.ManageTag.OptionsContent).setMaxLength(MaximumContentLength);

--- a/src/commands/tags/manage-tag.ts
+++ b/src/commands/tags/manage-tag.ts
@@ -5,7 +5,7 @@ import { DefaultLimits, fetchLimits } from '#lib/utilities/ring';
 import { getTag, makeTagChoices, sanitizeTagName, searchTag } from '#lib/utilities/tags';
 import { ActionRowBuilder, codeBlock, inlineCode, SlashCommandBooleanOption, SlashCommandStringOption, TextInputBuilder } from '@discordjs/builders';
 import { err, ok, Result } from '@sapphire/result';
-import { isNullish, isNullishOrEmpty } from '@sapphire/utilities';
+import { cutText, isNullish, isNullishOrEmpty } from '@sapphire/utilities';
 import { Command, RegisterCommand, RegisterSubCommand, type AutocompleteInteractionArguments } from '@skyra/http-framework';
 import { applyLocalizedBuilder, getSupportedUserLanguageT, resolveUserKey, type TypedFT, type TypedT, type Value } from '@skyra/http-framework-i18n';
 import { isAbortError } from '@skyra/safe-fetch';
@@ -44,7 +44,8 @@ export class UserCommand extends Command {
 		const embedColorResult = this.getEmbedColor(interaction, options);
 		if (embedColorResult.isErr()) return this.replyEphemeral(interaction, embedColorResult.unwrapErr());
 
-		const embed = options.embed ?? false;
+		// Default `embed` to `true` if `embed-color` is set.
+		const embed = options.embed ?? !isNullishOrEmpty(options['embed-color']);
 		const embedColor = embedColorResult.unwrap();
 		if (isNullishOrEmpty(options.content)) {
 			const t = getSupportedUserLanguageT(interaction);
@@ -52,7 +53,7 @@ export class UserCommand extends Command {
 				new TextInputBuilder()
 					.setCustomId('content')
 					.setLabel(t(LanguageKeys.Commands.ManageTag.ModalContent))
-					.setMaxLength(1900)
+					.setMaxLength(MaximumContentLength)
 					.setRequired(true)
 					.setStyle(TextInputStyle.Paragraph)
 			);
@@ -63,6 +64,11 @@ export class UserCommand extends Command {
 			});
 		}
 
+		const lengthLimit = embed ? 2048 : 2000;
+		if ([...options.content].length > lengthLimit) {
+			return this.replyLocalizedEphemeral(interaction, LanguageKeys.Commands.ManageTag.TooManyCharacters, lengthLimit);
+		}
+
 		await this.container.prisma.tag.create({ data: { name, content: options.content, embed, embedColor, guildId } });
 		return this.replyLocalizedEphemeral(interaction, LanguageKeys.Commands.ManageTag.AddSuccess, inlineCode(name));
 	}
@@ -71,13 +77,11 @@ export class UserCommand extends Command {
 		applyLocalizedBuilder(builder, LanguageKeys.Commands.ManageTag.Remove).addStringOption(makeNameOption().setAutocomplete(true))
 	)
 	public async remove(interaction: Command.ChatInputInteraction, options: Options) {
-		const name = sanitizeTagName(options.name);
-		if (isNullishOrEmpty(name)) return this.replyInvalidName(interaction, options.name);
+		const guildId = this.getGuildId(interaction);
+		const existing = await getTag(guildId, options.name);
+		if (isNullish(existing)) return this.replyLocalizedEphemeral(interaction, LanguageKeys.Commands.ManageTag.Unknown, inlineCode(options.name));
 
-		const result = await Result.fromAsync(
-			this.container.prisma.tag.delete({ where: { name_guildId: { guildId: this.getGuildId(interaction), name } } })
-		);
-
+		const result = await Result.fromAsync(this.container.prisma.tag.delete({ where: { id: existing.id } }));
 		const content = result.match({
 			ok: (tag) => resolveUserKey(interaction, LanguageKeys.Commands.ManageTag.RemoveSuccess, { value: inlineCode(tag.name) }),
 			err: () => LanguageKeys.Commands.ManageTag.Unknown
@@ -129,7 +133,7 @@ export class UserCommand extends Command {
 				new TextInputBuilder()
 					.setCustomId('content')
 					.setLabel(t(LanguageKeys.Commands.ManageTag.ModalContent))
-					.setMaxLength(1900)
+					.setMaxLength(MaximumContentLength)
 					.setRequired(true)
 					.setStyle(TextInputStyle.Paragraph)
 					.setValue(existing.content)
@@ -141,9 +145,15 @@ export class UserCommand extends Command {
 			});
 		}
 
+		const content = options.content ?? existing.content;
+		const lengthLimit = embed ? 2048 : 2000;
+		if ([...content].length > lengthLimit) {
+			return this.replyLocalizedEphemeral(interaction, LanguageKeys.Commands.ManageTag.TooManyCharacters, lengthLimit);
+		}
+
 		await this.container.prisma.tag.update({
 			where: { id: existing.id },
-			data: { name: nextName, content: options.content, embed, embedColor }
+			data: { name: nextName, content, embed, embedColor }
 		});
 		return this.replyLocalizedEphemeral(interaction, LanguageKeys.Commands.ManageTag.EditSuccess, inlineCode(nextName));
 	}
@@ -204,7 +214,7 @@ export class UserCommand extends Command {
 		const existing = await getTag(this.getGuildId(interaction), name);
 		return isNullish(existing)
 			? this.replyLocalizedEphemeral(interaction, LanguageKeys.Commands.ManageTag.Unknown, inlineCode(name))
-			: this.replyEphemeral(interaction, codeBlock('md', escapeCodeBlock(existing.content)));
+			: this.replyEphemeral(interaction, codeBlock('md', cutText(escapeCodeBlock(existing.content), 1980)));
 	}
 
 	private getGuildId(interaction: Command.Interaction) {
@@ -282,8 +292,24 @@ function makeNewNameOption() {
 	return applyLocalizedBuilder(new SlashCommandStringOption(), LanguageKeys.Commands.ManageTag.OptionsNewName).setMaxLength(32);
 }
 
+/**
+ * The content's max length is set to 4096, which is exactly 2048 * 2, however, we still set limits internally:
+ * - ≤2048 (embed: true)
+ * - ≤2000 (embed: false)
+ *
+ * Said limits are measured in code points, not characters, matching the checks the Discord API does. For reference:
+ * - 'a'.repeat(2000);
+ *   str.length     : 2000
+ *   [...str].length: 2000
+ *
+ * - '🔥'.repeat(2000);
+ *   str.length     : 4000
+ *   [...str].length: 2000
+ */
+const MaximumContentLength = 4096;
+
 function makeContentOption() {
-	return applyLocalizedBuilder(new SlashCommandStringOption(), LanguageKeys.Commands.ManageTag.OptionsContent).setMaxLength(1900);
+	return applyLocalizedBuilder(new SlashCommandStringOption(), LanguageKeys.Commands.ManageTag.OptionsContent).setMaxLength(MaximumContentLength);
 }
 
 function makeEmbedOption() {

--- a/src/interaction-handlers/tag.ts
+++ b/src/interaction-handlers/tag.ts
@@ -11,6 +11,12 @@ export class UserHandler extends InteractionHandler {
 	public async run(interaction: Interaction, parameters: Parameters) {
 		const content = interaction.data.components[0].components[0].value;
 		const embed = parameters[1] === '1';
+		const lengthLimit = embed ? 2048 : 2000;
+		if ([...content].length > lengthLimit) {
+			const content = resolveUserKey(interaction, LanguageKeys.Commands.ManageTag.TooManyCharacters, { value: lengthLimit });
+			return interaction.reply({ content, flags: MessageFlags.Ephemeral });
+		}
+
 		const embedColor = Number(parameters[2]);
 		const name = parameters[3];
 		const guildId = BigInt(interaction.guildId!);

--- a/src/lib/i18n/LanguageKeys/Commands/ManageTag.ts
+++ b/src/lib/i18n/LanguageKeys/Commands/ManageTag.ts
@@ -33,6 +33,7 @@ export const AliasUsed = FT<Value>('commands/manage-tag:aliasUsed');
 export const AliasIncompatible = FT<Value>('commands/manage-tag:aliasIncompatible');
 export const AliasRemoveSuccess = FT<Value>('commands/manage-tag:aliasRemoveSuccess');
 export const AliasRemoveFailed = FT<Value>('commands/manage-tag:aliasRemoveFailed');
+export const TooManyCharacters = FT<Value<number>>('commands/manage-tag:tooManyCharacters');
 export const TooManyAliases = FT<Value>('commands/manage-tag:tooManyAliases');
 export const TooManyTags = FT<{ amount: number; limit: number }>('commands/manage-tag:tooManyTags');
 export const AbortError = T('commands/manage-tag:abortError');

--- a/src/locales/en-US/commands/manage-tag.json
+++ b/src/locales/en-US/commands/manage-tag.json
@@ -37,7 +37,9 @@
 	"aliasRemoveSuccess": "Successfully removed the alias of {{value}}.",
 	"aliasSuccess": "Successfully edited {{value}}'s aliases.",
 	"aliasRemoveFailed": "I failed to remove the alias of {{value}} due to an unexpected error.",
+	"tooManyCharacters": "The content is too long, it must be shorter than {{value, number}} characters.",
 	"tooManyAliases": "You already reached the maximum number of aliases (10) for {{value}}.",
+	"tooManyTags": "You already reached the maximum number of tags ({{limit, number}}) with a total of {{amount, number}}",
 	"exists": "There is already a tag with that name, please use another name.",
 	"unknown": "There is no such tag under the specified name. Please try again with a different name."
 }


### PR DESCRIPTION
- Added missing `commands/manage-tag:tooManyTags` locale string.
- Made `embed` default to `true` if `embed-color` is defined.
- Fixed option selection on `/manage-tag remove`.
- Increased tag content limit from 1900 characters to 2048 codepoints (embed) or 2000 codepoints (plain).
- Fixed `/manage-tag edit` not sending the names correctly.

> **Note**: The `setMaxLength` calls on the modal's `TextInputBuilder`s were removed because of their 4000 limit, which is below 4096.
