### PR TITLE
feat: better tag autocomplete, remove `- id`

### DIFF
--- a/src/commands/search/youtube.ts
+++ b/src/commands/search/youtube.ts
@@ -1,8 +1,9 @@
+import { cut } from '#lib/common/strings';
 import { LanguageKeys } from '#lib/i18n/LanguageKeys';
 import type { YouTubeResult, YouTubeResultId, YouTubeResultSnippet } from '#lib/types/youtube';
 import { getLinkFromResultId, getSelectMenuValue } from '#lib/utilities/youtube';
 import { ActionRowBuilder, StringSelectMenuBuilder } from '@discordjs/builders';
-import { cutText, isNullishOrEmpty } from '@sapphire/utilities';
+import { isNullishOrEmpty } from '@sapphire/utilities';
 import { envParseString } from '@skyra/env-utilities';
 import { Command, MessageResponseOptions, RegisterCommand } from '@skyra/http-framework';
 import { applyLocalizedBuilder, createSelectMenuChoiceName, resolveUserKey } from '@skyra/http-framework-i18n';
@@ -62,7 +63,7 @@ export class UserCommand extends Command {
 				options.push({
 					// Handle edge case with channelTitle: ''.
 					label: this.getLabel(item.snippet),
-					description: cutText(he.decode(item.snippet.title), 50),
+					description: cut(he.decode(item.snippet.title), 50),
 					value,
 					default: first === null
 				});
@@ -81,7 +82,7 @@ export class UserCommand extends Command {
 	}
 
 	private getLabel(snippet: YouTubeResultSnippet): string {
-		if (!isNullishOrEmpty(snippet.channelTitle)) return cutText(he.decode(snippet.channelTitle), 25);
+		if (!isNullishOrEmpty(snippet.channelTitle)) return cut(he.decode(snippet.channelTitle), 25);
 		return snippet.channelId === 'UC' ? 'YouTube Music' : snippet.channelId;
 	}
 

--- a/src/commands/tags/manage-tag.ts
+++ b/src/commands/tags/manage-tag.ts
@@ -1,11 +1,12 @@
 import { escapeCodeBlock } from '#lib/common/escape';
+import { cut } from '#lib/common/strings';
 import { LanguageKeys } from '#lib/i18n/LanguageKeys';
 import { parseColor } from '#lib/utilities/color';
 import { DefaultLimits, fetchLimits } from '#lib/utilities/ring';
 import { getTag, makeTagChoices, sanitizeTagName, searchTag } from '#lib/utilities/tags';
 import { ActionRowBuilder, codeBlock, inlineCode, SlashCommandBooleanOption, SlashCommandStringOption, TextInputBuilder } from '@discordjs/builders';
 import { err, ok, Result } from '@sapphire/result';
-import { cutText, isNullish, isNullishOrEmpty } from '@sapphire/utilities';
+import { isNullish, isNullishOrEmpty } from '@sapphire/utilities';
 import { Command, RegisterCommand, RegisterSubCommand, type AutocompleteInteractionArguments } from '@skyra/http-framework';
 import { applyLocalizedBuilder, getSupportedUserLanguageT, resolveUserKey, type TypedFT, type TypedT, type Value } from '@skyra/http-framework-i18n';
 import { isAbortError } from '@skyra/safe-fetch';
@@ -228,7 +229,7 @@ export class UserCommand extends Command {
 		const existing = await getTag(this.getGuildId(interaction), name);
 		return isNullish(existing)
 			? this.replyLocalizedEphemeral(interaction, LanguageKeys.Commands.ManageTag.Unknown, inlineCode(name))
-			: this.replyEphemeral(interaction, codeBlock('md', cutText(escapeCodeBlock(existing.content), 1980)));
+			: this.replyEphemeral(interaction, codeBlock('md', cut(escapeCodeBlock(existing.content), 1980)));
 	}
 
 	private getGuildId(interaction: Command.Interaction) {

--- a/src/lib/common/strings.ts
+++ b/src/lib/common/strings.ts
@@ -1,0 +1,4 @@
+export function cut(string: string, length: number): string {
+	const codePoints = [...string];
+	return codePoints.length <= length ? string : `${codePoints.slice(0, length - 3).join('')}...`;
+}

--- a/src/lib/utilities/tags.ts
+++ b/src/lib/utilities/tags.ts
@@ -1,3 +1,4 @@
+import { cut } from '#lib/common/strings';
 import type { Tag, TagAlias } from '@prisma/client';
 import { isNullishOrEmpty } from '@sapphire/utilities';
 import { container } from '@skyra/http-framework';
@@ -14,18 +15,13 @@ export function searchTag(guildId: bigint, query?: string | null) {
 		where: isNullishOrEmpty(query)
 			? { guildId }
 			: { guildId, OR: [{ name: { startsWith: query } }, { aliases: { some: { name: { startsWith: query } } } }] },
-		select: { id: true, name: true },
+		select: { id: true, name: true, content: true },
 		take: 25
 	});
 }
 
 export function getTag<A>(guildId: bigint, query: string, aliases?: A): Promise<(A extends true ? FullTag : Tag) | null>;
 export function getTag(guildId: bigint, query: string, aliases = false) {
-	if (query.endsWith('\u200B')) {
-		const id = BigInt(query.slice(query.lastIndexOf(' ') + 1, -1));
-		return container.prisma.tag.findFirst({ where: { id, guildId }, include: aliases ? { aliases: true } : undefined });
-	}
-
 	return container.prisma.tag.findFirst({
 		where: { guildId, OR: [{ name: query }, { aliases: { some: { name: query } } }] },
 		include: aliases ? { aliases: true } : undefined
@@ -34,10 +30,10 @@ export function getTag(guildId: bigint, query: string, aliases = false) {
 
 type FullTag = Tag & { aliases: TagAlias[] };
 
-export function makeTagChoice(tag: Pick<Tag, 'id' | 'name'>) {
-	return { name: tag.name, value: `${tag.name} - ${tag.id}\u200B` } satisfies APIApplicationCommandOptionChoice;
+export function makeTagChoice(tag: Pick<Tag, 'id' | 'name' | 'content'>) {
+	return { name: cut(`${tag.name} — ${tag.content}`, 100), value: tag.name } satisfies APIApplicationCommandOptionChoice;
 }
 
-export function makeTagChoices(tags: readonly Pick<Tag, 'id' | 'name'>[]) {
+export function makeTagChoices(tags: readonly Pick<Tag, 'id' | 'name' | 'content'>[]) {
 	return tags.map((tag) => makeTagChoice(tag));
 }


### PR DESCRIPTION
`cut(string, length)` is used because Sapphire's `cutText(string, length)` counts character length instead of codepoint length, and it cuts down to the last space, which while it works for most of the cases, it fails at some edge cases such as cutting an AC suggestion where the tag is literally 🔥 times +100.
