### PR TITLE
feat(weather): use user-specific defaults

### DIFF
--- a/src/commands/search/weather.ts
+++ b/src/commands/search/weather.ts
@@ -18,6 +18,7 @@ import {
 	applyLocalizedBuilder,
 	createSelectMenuChoiceName,
 	getSupportedLanguageT,
+	getSupportedUserLanguageT,
 	resolveUserKey,
 	type TFunction,
 	type TypedT
@@ -60,7 +61,9 @@ export class UserCommand extends Command {
 		const [current] = data.current_condition;
 		const weatherDescription = UserCommand.getWeatherDescription(current, base);
 
-		const useImperial = UserCommand.shouldUseImperial(t, args.system ?? 'auto');
+		// Take for example when the user's locale is 'en-GB' and the guild's language is 'en-US'. The default displayed
+		// at them will be "Auto (Metric)" (en-GB), but without this, the default would be "Auto (Imperial)" (en-US).
+		const useImperial = UserCommand.shouldUseImperial(getSupportedUserLanguageT(interaction), args.system ?? 'auto');
 
 		const resolved = useImperial
 			? resolveCurrentConditionsImperial(current, t)


### PR DESCRIPTION
As noted in Crowdin, while en-US displays `Auto (Imperial)` under the `system` option, all other languages, en-GB included, display `Auto (Metric)`.

The current code did not honour it, e.g. when the server's preferred locale is en-US and the user's locale is en-GB, the default displayed would be `Auto (Metric)`, but because it used the guild's locale, the default would actually be `Auto (Imperial)`. With this change, the user default is now honored.
