### PR TITLE
refactor: add and use default 25 biggest cities over 25 first entries

### DIFF
--- a/src/lib/utilities/tz.ts
+++ b/src/lib/utilities/tz.ts
@@ -48,31 +48,31 @@ function getSearchScore(id: string, key: string, value: TimeZone) {
 	return score;
 }
 const defaults = [
-	'africa/cairo', // Egypt
-	'america/argentina/buenos aires', // Argentina
-	'america/los angeles', // US
-	'america/mexico city', // Mexico
-	'america/new york', // US
-	'america/phoenix', // US, Canada
-	'america/sao paulo', // Brazil
-	'america/toronto', // Canada, Bahamas
-	'asia/bangkok', // Thailand, Christmas Island, Cambodia, Laos, Vietnam
 	'asia/kolkata', // India
-	'asia/seoul', // South Korea
-	'asia/shanghai', // China
-	'asia/singapore', // Singapore
-	'asia/tokyo', // Japan
-	'australia/brisbane', // Australia
-	'australia/melbourne', // Australia
-	'australia/perth', // Australia
-	'australia/sydney', // Australia
-	'europe/berlin', // Berlin, Denmark, Norway, Sweden, Svalbard & Jan Mayen
-	'europe/istanbul', // Turkey
-	'europe/london', // Great Britain, Guernsey, Isle of Man, Jersey
-	'europe/madrid', // Spain
+	'america/los angeles', // United States, West Coast
+	'america/new york', // United States, East Coast
+	'america/phoenix', // United States, Mountain Central
+	'europe/london', // United Kingdom, Ireland
+	'pacific/auckland', // New Zealand, Antarctica
 	'europe/paris', // France, Monaco
+	'america/mexico city', // Mexico
+	'australia/melbourne', // Australia
+	'australia/sydney', // Australia
+	'australia/perth', // Australia
+	'australia/brisbane', // Australia
+	'america/toronto', // Canada, Bahamas
+	'america/sao paulo', // Brazil
+	'america/argentina/buenos aires', // Argentina
+	'asia/tokyo', // Japan
+	'europe/madrid', // Spain
+	'asia/singapore', // Singapore
+	'asia/bangkok', // Thailand, Christmas Island, Cambodia, Laos, Vietnam
+	'europe/istanbul', // Turkey
+	'asia/seoul', // South Korea
+	'europe/berlin', // Berlin, Denmark, Norway, Sweden, Svalbard & Jan Mayen
 	'europe/prague', // Czech Republic, Slovakia
-	'pacific/auckland' // New Zealand, Antarctica
+	'asia/shanghai', // China
+	'africa/cairo' // Egypt
 ].map((value) => tz.get(value)!);
 
 export function searchTimeZone(id: string): readonly TimeZone[] {

--- a/src/lib/utilities/tz.ts
+++ b/src/lib/utilities/tz.ts
@@ -75,7 +75,7 @@ const defaults = [
 	'europe/paris'
 ].map((value) => tz.get(value)!);
 
-export function searchTimeZone(id: string) {
+export function searchTimeZone(id: string): readonly TimeZone[] {
 	if (id.length === 0) return defaults;
 	if (id.length > MaximumLength) return [];
 

--- a/src/lib/utilities/tz.ts
+++ b/src/lib/utilities/tz.ts
@@ -60,7 +60,7 @@ const defaults = [
 	'asia/kolkata', // India
 	'asia/seoul', // South Korea
 	'asia/shanghai', // China
-	'asia/singapore', // Singapore, Malaysia
+	'asia/singapore', // Singapore
 	'asia/tokyo', // Japan
 	'australia/brisbane', // Australia
 	'australia/melbourne', // Australia
@@ -68,7 +68,7 @@ const defaults = [
 	'australia/sydney', // Australia
 	'europe/berlin', // Berlin, Denmark, Norway, Sweden, Svalbard & Jan Mayen
 	'europe/istanbul', // Turkey
-	'europe/london', // Britain, Guernsey, Isle of Man, Jersey
+	'europe/london', // Great Britain, Guernsey, Isle of Man, Jersey
 	'europe/madrid', // Spain
 	'europe/paris', // France, Monaco
 	'europe/prague', // Czech Republic, Slovakia

--- a/src/lib/utilities/tz.ts
+++ b/src/lib/utilities/tz.ts
@@ -48,31 +48,31 @@ function getSearchScore(id: string, key: string, value: TimeZone) {
 	return score;
 }
 const defaults = [
-	'africa/cairo',
-	'africa/khartoum',
-	'america/argentina/buenos aires',
-	'america/bogota',
-	'america/lima',
-	'america/mexico city',
-	'america/new york',
-	'america/sao paulo',
-	'america/toronto',
-	'asia/bangkok',
-	'asia/dhaka',
-	'asia/karachi',
-	'asia/kolkata',
-	'asia/manila',
-	'asia/seoul',
-	'asia/shanghai',
-	'asia/singapore',
-	'asia/tokyo',
-	'asia/yangon',
-	'australia/sydney',
-	'europe/istanbul',
-	'europe/london',
-	'europe/madrid',
-	'europe/moscow',
-	'europe/paris'
+	'africa/cairo', // Egypt
+	'america/argentina/buenos aires', // Argentina
+	'america/los angeles', // US
+	'america/mexico city', // Mexico
+	'america/new york', // US
+	'america/phoenix', // US, Canada
+	'america/sao paulo', // Brazil
+	'america/toronto', // Canada, Bahamas
+	'asia/bangkok', // Thailand, Christmas Island, Cambodia, Laos, Vietnam
+	'asia/kolkata', // India
+	'asia/seoul', // South Korea
+	'asia/shanghai', // China
+	'asia/singapore', // Singapore, Malaysia
+	'asia/tokyo', // Japan
+	'australia/brisbane', // Australia
+	'australia/melbourne', // Australia
+	'australia/perth', // Australia
+	'australia/sydney', // Australia
+	'europe/berlin', // Berlin, Denmark, Norway, Sweden, Svalbard & Jan Mayen
+	'europe/istanbul', // Turkey
+	'europe/london', // Britain, Guernsey, Isle of Man, Jersey
+	'europe/madrid', // Spain
+	'europe/paris', // France, Monaco
+	'europe/prague', // Czech Republic, Slovakia
+	'pacific/auckland' // New Zealand, Antarctica
 ].map((value) => tz.get(value)!);
 
 export function searchTimeZone(id: string): readonly TimeZone[] {

--- a/src/lib/utilities/tz.ts
+++ b/src/lib/utilities/tz.ts
@@ -54,7 +54,7 @@ const defaults = [
 	'america/phoenix', // United States, Mountain Central
 	'europe/london', // United Kingdom, Ireland
 	'pacific/auckland', // New Zealand, Antarctica
-	'europe/paris', // France, Monaco
+	'europe/paris', // France, Monaco, Belgium, The Netherlands, Luxembourg
 	'america/mexico city', // Mexico
 	'australia/melbourne', // Australia
 	'australia/sydney', // Australia

--- a/src/lib/utilities/tz.ts
+++ b/src/lib/utilities/tz.ts
@@ -91,11 +91,6 @@ function getSearchScore(id: string, key: string, value: TimeZone) {
 	return score;
 }
 
-interface RawTimeZone {
-	codes: string[];
-	name: string;
-}
-
 export interface TimeZone {
 	countries: TimeZoneCountry[];
 	name: string;
@@ -104,5 +99,10 @@ export interface TimeZone {
 
 export interface TimeZoneCountry {
 	code: string;
+	name: string;
+}
+
+interface RawTimeZone {
+	codes: string[];
 	name: string;
 }

--- a/src/lib/utilities/tz.ts
+++ b/src/lib/utilities/tz.ts
@@ -47,8 +47,36 @@ function getSearchScore(id: string, key: string, value: TimeZone) {
 
 	return score;
 }
+const defaults = [
+	'africa/cairo',
+	'africa/khartoum',
+	'america/argentina/buenos aires',
+	'america/bogota',
+	'america/lima',
+	'america/mexico city',
+	'america/new york',
+	'america/sao paulo',
+	'america/toronto',
+	'asia/bangkok',
+	'asia/dhaka',
+	'asia/karachi',
+	'asia/kolkata',
+	'asia/manila',
+	'asia/seoul',
+	'asia/shanghai',
+	'asia/singapore',
+	'asia/tokyo',
+	'asia/yangon',
+	'australia/sydney',
+	'europe/istanbul',
+	'europe/london',
+	'europe/madrid',
+	'europe/moscow',
+	'europe/paris'
+].map((value) => tz.get(value)!);
 
 export function searchTimeZone(id: string) {
+	if (id.length === 0) return defaults;
 	if (id.length > MaximumLength) return [];
 
 	id = id.toLowerCase();


### PR DESCRIPTION
By default, Teryl was matching the first 25, which resulted on the initial search being mostly useless as they were 19 from Africa and 6 from USA (Adak, Anchorage, Araguaina, Buenos Aires, Catamarca, Córdoba).

With the new defaults, the top 25 most relevant biggest cities with an IANA timezone, sorted alphabetically, will be shown. List comes from https://worldpopulationreview.com/world-cities.
