### PR TITLE
feat(reminders): display subscribed reminders in `show`

### DIFF
--- a/src/lib/i18n/LanguageKeys/Commands/Reminders.ts
+++ b/src/lib/i18n/LanguageKeys/Commands/Reminders.ts
@@ -22,11 +22,12 @@ export const Delete = 'commands/reminders:delete';
 export const DeleteContent = FT<{ id: string; time: string; content: string }>('commands/reminders:deleteContent');
 
 export const Show = 'commands/reminders:show';
+export const LinkTo = T('commands/reminders:linkTo');
 
 export const List = 'commands/reminders:list';
 export const ListEmpty = FT<{ commandId: string }>('commands/reminders:listEmpty');
 
-export const InvalidId = FT<Value>('commands/reminders:invalidId');
+export const InvalidId = FT<{ id: string }>('commands/reminders:invalidId');
 export const InvalidDuration = FT<Value>('commands/reminders:invalidDuration');
 export const DurationTooShort = FT<Value>('commands/reminders:durationTooShort');
 export const DurationTooLong = FT<Value>('commands/reminders:durationTooLong');

--- a/src/lib/utilities/components.ts
+++ b/src/lib/utilities/components.ts
@@ -1,0 +1,5 @@
+import { ActionRowBuilder, type ButtonBuilder } from '@discordjs/builders';
+
+export function makeButtonRow(...buttons: readonly ButtonBuilder[]) {
+	return new ActionRowBuilder<ButtonBuilder>().addComponents(...buttons);
+}

--- a/src/locales/en-US/commands/reminders.json
+++ b/src/locales/en-US/commands/reminders.json
@@ -23,6 +23,7 @@
 	"deleteContent": "Successfully deleted the reminder {{id}} which was set to deliver on {{time}} with the following contents:{{content}}",
 	"showName": "show",
 	"showDescription": "Shows one of your reminders",
+	"linkTo": "Link to Message",
 	"listName": "list",
 	"listDescription": "Lists all of your reminders",
 	"listEmpty": "There are no reminders on your user, but you can create new ones using </reminders create:{{commandId}}>.",


### PR DESCRIPTION
Nice.

Also fixes an invalid option when `show` was used against an invalid ID.