### PR TITLE
fix(emoji): update emoji source ids

### DIFF
--- a/src/lib/utilities/emoji.ts
+++ b/src/lib/utilities/emoji.ts
@@ -67,8 +67,8 @@ const EmojipediaCodes = {
 	[EmojiSource.Google]: '350',
 	[EmojiSource.Microsoft]: '319',
 	[EmojiSource.Samsung]: '349',
-	[EmojiSource.Twitter]: '322',
-	[EmojiSource.WhatsApp]: '326'
+	[EmojiSource.Twitter]: '351',
+	[EmojiSource.WhatsApp]: '352'
 } as const satisfies Record<EmojiSource, string>;
 
 export interface DiscordEmoji {


### PR DESCRIPTION
I noticed Unicode 15's emojis are supported when I pasted 🩷🩵 on Twitter, pointing that Twemoji was updated to support both emojis, but Teryl didn't support them... turns out the ID changed. I updated the entire list of IDs.
