### PR TITLE
Add slash commands for get content JSON 

### DIFF
--- a/src/commands/content.ts
+++ b/src/commands/content.ts
@@ -1,11 +1,21 @@
 import { escapeCodeBlock } from '#lib/common/escape';
 import { LanguageKeys } from '#lib/i18n/LanguageKeys';
-import { codeBlock } from '@discordjs/builders';
+import { codeBlock, SlashCommandStringOption, SlashCommandUserOption } from '@discordjs/builders';
 import type { RawFile } from '@discordjs/rest';
-import { Command, RegisterMessageCommand, RegisterUserCommand, type TransformedArguments } from '@skyra/http-framework';
-import { applyNameLocalizedBuilder } from '@skyra/http-framework-i18n';
-import { MessageFlags } from 'discord-api-types/v10';
+import {
+	Command,
+	RegisterCommand,
+	RegisterMessageCommand,
+	RegisterSubCommand,
+	RegisterUserCommand,
+	type TransformedArguments
+} from '@skyra/http-framework';
+import { applyLocalizedBuilder, applyNameLocalizedBuilder, resolveUserKey } from '@skyra/http-framework-i18n';
+import { type APIMessage, MessageFlags, Routes } from 'discord-api-types/v10';
+import { isNullishOrEmpty } from '@sapphire/utilities';
+import { Result } from '@sapphire/result';
 
+@RegisterCommand((builder) => applyLocalizedBuilder(builder, LanguageKeys.Commands.Content.RootName, LanguageKeys.Commands.Content.RootDescription))
 export class UserCommand extends Command {
 	@RegisterMessageCommand((builder) => applyNameLocalizedBuilder(builder, LanguageKeys.Commands.Content.MessageJsonName))
 	public message(interaction: Command.MessageInteraction, options: TransformedArguments.Message) {
@@ -18,7 +28,40 @@ export class UserCommand extends Command {
 		return this.shared(interaction, data, options.user.id);
 	}
 
-	private async shared(interaction: Command.MessageInteraction | Command.UserInteraction, data: object, id: string) {
+	// Slash commands:
+	@RegisterSubCommand((builder) =>
+		applyLocalizedBuilder(builder, LanguageKeys.Commands.Content.User).addUserOption(createUserOption().setRequired(true))
+	)
+	public async slashUser(interaction: Command.ChatInputInteraction, options: UserOptions) {
+		if (isNullishOrEmpty(options.user)) {
+			const content = resolveUserKey(interaction, LanguageKeys.Commands.Content.UserMissingOptions);
+			return interaction.reply({ content, flags: MessageFlags.Ephemeral });
+		}
+		const data = options.user.member ? { ...options.user.member, user: options.user.user } : options.user.user;
+		return this.shared(interaction, data, options.user.user.id);
+	}
+
+	@RegisterSubCommand((builder) =>
+		applyLocalizedBuilder(builder, LanguageKeys.Commands.Content.Message).addStringOption(createMessageIdOption().setRequired(true))
+	)
+	public async slashMessage(interaction: Command.ChatInputInteraction, options: MessageOptions) {
+		if (isNullishOrEmpty(options.id)) {
+			const content = resolveUserKey(interaction, LanguageKeys.Commands.Content.MessageMissingOptions);
+			return interaction.reply({ content, flags: MessageFlags.Ephemeral });
+		}
+
+		const result = await Result.fromAsync(this.container.rest.get(Routes.channelMessage(interaction.channel.id, options.id)));
+		if (result.isErr()) {
+			const content = resolveUserKey(interaction, LanguageKeys.Commands.Content.MessageInvalidOptions);
+			return interaction.reply({ content, flags: MessageFlags.Ephemeral });
+		}
+
+		const message = result.unwrap() as APIMessage;
+		return this.shared(interaction, message, message.id);
+	}
+
+	// Shared
+	private async shared(interaction: Command.MessageInteraction | Command.UserInteraction | Command.ChatInputInteraction, data: object, id: string) {
 		const json = JSON.stringify(data, null, '\t');
 		if (json.length < 1988) return interaction.reply({ content: codeBlock('json', escapeCodeBlock(json)), flags: MessageFlags.Ephemeral });
 
@@ -26,4 +69,16 @@ export class UserCommand extends Command {
 		const file = { name: `${id}.json`, data: Buffer.from(json, 'utf8'), contentType: 'application/json' } satisfies RawFile;
 		return response.update({ files: [file] });
 	}
+}
+function createMessageIdOption() {
+	return applyLocalizedBuilder(new SlashCommandStringOption(), LanguageKeys.Commands.Content.OptionsMessageId);
+}
+function createUserOption() {
+	return applyLocalizedBuilder(new SlashCommandUserOption(), LanguageKeys.Commands.Content.OptionsUser);
+}
+interface MessageOptions {
+	id: string;
+}
+interface UserOptions {
+	user: TransformedArguments.User;
 }

--- a/src/lib/i18n/LanguageKeys/Commands/Content.ts
+++ b/src/lib/i18n/LanguageKeys/Commands/Content.ts
@@ -1,5 +1,19 @@
 import { T } from '@skyra/http-framework-i18n';
 
 // Root
+export const RootName = T('commands/content:name');
+export const RootDescription = T('commands/content:description');
+
 export const MessageJsonName = T('commands/content:messageJsonName');
 export const UserJsonName = T('commands/content:userJsonName');
+
+export const User = 'commands/content:user';
+export const Message = 'commands/content:message';
+
+export const OptionsUser = 'commands/content:optionsUser';
+export const OptionsMessageId = 'commands/content:optionsMessageId';
+
+export const UserMissingOptions = T('commands/content:userMissingOptions');
+export const MessageMissingOptions = T('commands/content:messageMissingOptions');
+
+export const MessageInvalidOptions = T('commands/content:messageInvalidOptions');

--- a/src/locales/en-GB/commands/content.json
+++ b/src/locales/en-GB/commands/content.json
@@ -1,4 +1,17 @@
 {
+	"name": "content",
+	"description": "Get content in JSON format of a user or message",
+	"userName": "user",
+	"userDescription": "Get user info in JSON format",
+	"optionsUserName": "user",
+	"optionsUserDescription": "The user you would like to get",
+	"userMissingOptions": "You must specify the user ID",
+	"messageName": "message",
+	"messageDescription": "Get message content in JSON format",
+	"optionsMessageIdName": "id",
+	"optionsMessageIdDescription": "The ID of the Message you would like to get",
+	"messageMissingOptions": "You must specify the message ID",
+	"messageInvalidOptions": "That message ID is not valid",
 	"messageJsonName": "Get Message JSON",
 	"userJsonName": "Get User JSON"
 }

--- a/src/locales/en-US/commands/content.json
+++ b/src/locales/en-US/commands/content.json
@@ -1,4 +1,17 @@
 {
+	"name": "content",
+	"description": "Get content in JSON format of a user or message",
+	"userName": "user",
+	"userDescription": "Get user info in JSON format",
+	"optionsUserName": "user",
+	"optionsUserDescription": "The user you would like to get",
+	"userMissingOptions": "You must specify the user ID",
+	"messageName": "message",
+	"messageDescription": "Get message content in JSON format",
+	"optionsMessageIdName": "id",
+	"optionsMessageIdDescription": "The ID of the Message you would like to get",
+	"messageMissingOptions": "You must specify the message ID",
+	"messageInvalidOptions": "That message ID is not valid",
 	"messageJsonName": "Get Message JSON",
 	"userJsonName": "Get User JSON"
 }


### PR DESCRIPTION
### Description

Since ephemeral messages are lost when you need to scroll down enough for the client to fetch new messages, the existing Apps->Get [message/user] JSON tool responses can only be functionally used if the user/message is quite recent.

- This attempts to add slash commands for each of these 2 functions.
- This is basically an issue/suggestion with near-complete(?) code example.


### Tested?
- It is **untested**, I'm not sure if there would be a conflict from using both message/user and slash commands in the same class, however I don't see why it would, either.

### Thoughts
- If I'm just dense and there is a way to make ephemeral messages persist even when I'm scrolled back several days, please enlighten me!

PS. I will try to set it up and test it when I get more time, but yea let me know if this is Dead on Arrival, please, thanks!

-Cyr