### PR TITLE
refactor(reddit): improve errors and handling

### DIFF
--- a/src/lib/i18n/LanguageKeys/Commands/Reddit.ts
+++ b/src/lib/i18n/LanguageKeys/Commands/Reddit.ts
@@ -11,7 +11,7 @@ export const Subreddit = 'commands/reddit:subreddit';
 export const Post = 'commands/reddit:post';
 
 export const InvalidName = T('commands/reddit:invalidName');
-export const InvalidPostKey = T('commands/reddit:invalidPostKey');
+export const InvalidPostLink = FT<{ formats: string }>('commands/reddit:invalidPostLink');
 export const Banned = T('commands/reddit:banned');
 export const PostResult = FT<{ title: string; author: string; url: string }>('commands/reddit:post');
 export const NoPosts = T('commands/reddit:noPosts');

--- a/src/locales/en-US/commands/reddit.json
+++ b/src/locales/en-US/commands/reddit.json
@@ -10,7 +10,7 @@
 	"optionsPostName": "post",
 	"optionsPostDescription": "A reddit post's link",
 	"invalidName": "Subreddits must be between 3 and 21 characters long, and contain only letters, numbers, or underscores. The `/r/` and `r/` prefixes are also supported.",
-	"invalidPostKey": "Posts must have a key of at least 6 characters, and only contain letters and numbers.",
+	"invalidPostLink": "The specified URL is not a valid Reddit post. Please make sure you have typed the link correctly. The allowed formats are:\n\n{{formats}}",
 	"banned": "The specified subreddit is not deemed to be safe, please try another one.",
 	"post": "**{{title}}** submitted by {{author}}\n{{url}}",
 	"noPosts": "There are no posts available in the specified subreddit. Please make sure you have typed the name correctly.",


### PR DESCRIPTION
Reusing the strings was a bad move, as it made the errors more confusing. Realistically, while users *may* know a subreddit's name from memory (because they're usually easy to remember), comment IDs are random and thus, not always easy to remember at all, making the source of this input almost exclusively copied URLs from the browser or the app.

The before and after this update can be seen here:
![DiscordCanary_DRnS9IjmIp](https://github.com/skyra-project/teryl/assets/24852502/cd3070d2-d3ec-4a02-9302-1400ec69775c)

This PR also fixes a bug where `/reddit post` would lowercase the entire URL, `key` included.

The code also got a few more refactors:
- Using `Root`, as all the other bots (and Teryl in other commands) do.
- Check for `match.groups` rather than `match?.groups?.subreddit` and `match?.groups?.key`, which was unnecessary as the specific RegExp not matching one wouldn't match the other.
- Documented the command's RegExps to understand them better.
