### PR TITLE
build: dbmigrate docker image

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'src/**'
       - 'Dockerfile'
+      - 'Dockerfile.dbmigrate'
       - '.github/workflows/continuous-delivery.yml'
       - 'package.json'
 
@@ -34,3 +35,27 @@ jobs:
           push: true
           context: .
           tags: ghcr.io/skyra-project/teryl:latest
+
+  PublishDbMigrate:
+    name: Publish Teryl's DB Migration image to container registries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Teryl Docker image
+        uses: docker/build-push-action@v5.3.0
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile.dbmigrate
+          tags: ghcr.io/skyra-project/teryl-dbmigrate:latest

--- a/Dockerfile.dbmigrate
+++ b/Dockerfile.dbmigrate
@@ -1,0 +1,36 @@
+# ================ #
+#    Base Stage    #
+# ================ #
+
+FROM node:20-alpine AS base
+
+WORKDIR /usr/src/app
+
+ENV YARN_DISABLE_GIT_HOOKS=1
+
+COPY --chown=node:node yarn.lock .
+COPY --chown=node:node package.json .
+COPY --chown=node:node .yarnrc.yml .
+COPY --chown=node:node .yarn/ .yarn/
+
+# ================== #
+#   DBMigrate Stage  #
+# ================== #
+
+FROM base AS dbmigrate
+
+ENV NODE_ENV="development"
+
+COPY --chown=node:node tsconfig.base.json .
+COPY --chown=node:node prisma/ prisma/
+COPY --chown=node:node src/ src/
+
+RUN yarn install --immutable
+RUN yarn run prisma:generate
+RUN yarn run build
+
+ENV NODE_ENV="production"
+
+USER node
+
+CMD [ "yarn", "run", "prisma:migrate" ]

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"dev": "yarn build && yarn start",
 		"watch": "tsc -b src -w",
 		"prisma:generate": "yarn prisma generate",
+		"prisma:migrate": "yarn prisma migrate deploy",
 		"clean": "rimraf dist/",
 		"start": "node --enable-source-maps dist/main.js",
 		"test": "vitest run",


### PR DESCRIPTION
This needs testing but I just wanted to braindump my current thoughts on GitHub.

The way to configure this is to pass the environment variable `DATABASE_URL` through the `-e` flag for `docker run` or the docker compose file. Setting it to something like 
```
DATABASE_URL=postgresql://postgres:postgres@postgres:5432/teryl?schema=public
```
wherein `postgres@5432` targets the containerized postgres so it goes docker-to-docker 