### PR TITLE
refactor(emoji): update sources

### DIFF
--- a/src/commands/create-emoji.ts
+++ b/src/commands/create-emoji.ts
@@ -43,6 +43,7 @@ const EmojiRoot = LanguageKeys.Commands.Emoji;
 				createSelectMenuChoiceName(EmojiRoot.OptionsVariantFacebook, { value: EmojiSource.Facebook }),
 				createSelectMenuChoiceName(EmojiRoot.OptionsVariantGoogle, { value: EmojiSource.Google }),
 				createSelectMenuChoiceName(EmojiRoot.OptionsVariantMicrosoft, { value: EmojiSource.Microsoft }),
+				createSelectMenuChoiceName(EmojiRoot.OptionsVariantMicrosoftFluent, { value: EmojiSource.MicrosoftFluent }),
 				createSelectMenuChoiceName(EmojiRoot.OptionsVariantSamsung, { value: EmojiSource.Samsung }),
 				createSelectMenuChoiceName(EmojiRoot.OptionsVariantTwitter, { value: EmojiSource.Twitter }),
 				createSelectMenuChoiceName(EmojiRoot.OptionsVariantWhatsApp, { value: EmojiSource.WhatsApp })

--- a/src/commands/emoji.ts
+++ b/src/commands/emoji.ts
@@ -24,6 +24,7 @@ const Root = LanguageKeys.Commands.Emoji;
 				createSelectMenuChoiceName(Root.OptionsVariantFacebook, { value: EmojiSource.Facebook }),
 				createSelectMenuChoiceName(Root.OptionsVariantGoogle, { value: EmojiSource.Google }),
 				createSelectMenuChoiceName(Root.OptionsVariantMicrosoft, { value: EmojiSource.Microsoft }),
+				createSelectMenuChoiceName(Root.OptionsVariantMicrosoftFluent, { value: EmojiSource.MicrosoftFluent }),
 				createSelectMenuChoiceName(Root.OptionsVariantSamsung, { value: EmojiSource.Samsung }),
 				createSelectMenuChoiceName(Root.OptionsVariantTwitter, { value: EmojiSource.Twitter }),
 				createSelectMenuChoiceName(Root.OptionsVariantWhatsApp, { value: EmojiSource.WhatsApp })

--- a/src/lib/i18n/LanguageKeys/Commands/Emoji.ts
+++ b/src/lib/i18n/LanguageKeys/Commands/Emoji.ts
@@ -11,6 +11,7 @@ export const OptionsVariantApple = T('commands/emoji:optionsVariantApple');
 export const OptionsVariantFacebook = T('commands/emoji:optionsVariantFacebook');
 export const OptionsVariantGoogle = T('commands/emoji:optionsVariantGoogle');
 export const OptionsVariantMicrosoft = T('commands/emoji:optionsVariantMicrosoft');
+export const OptionsVariantMicrosoftFluent = T('commands/emoji:optionsVariantMicrosoftFluent');
 export const OptionsVariantSamsung = T('commands/emoji:optionsVariantSamsung');
 export const OptionsVariantTwitter = T('commands/emoji:optionsVariantTwitter');
 export const OptionsVariantWhatsApp = T('commands/emoji:optionsVariantWhatsApp');

--- a/src/lib/utilities/emoji.ts
+++ b/src/lib/utilities/emoji.ts
@@ -56,19 +56,21 @@ export enum EmojiSource {
 	Facebook = 'facebook',
 	Google = 'google',
 	Microsoft = 'microsoft',
+	MicrosoftFluent = 'microsoft-3D-fluent',
 	Samsung = 'samsung',
 	Twitter = 'twitter',
 	WhatsApp = 'whatsapp'
 }
 
 const EmojipediaCodes = {
-	[EmojiSource.Apple]: '354',
+	[EmojiSource.Apple]: '391',
 	[EmojiSource.Facebook]: '355',
-	[EmojiSource.Google]: '350',
-	[EmojiSource.Microsoft]: '319',
-	[EmojiSource.Samsung]: '349',
-	[EmojiSource.Twitter]: '351',
-	[EmojiSource.WhatsApp]: '352'
+	[EmojiSource.Google]: '412',
+	[EmojiSource.Microsoft]: '407',
+	[EmojiSource.MicrosoftFluent]: '406',
+	[EmojiSource.Samsung]: '405',
+	[EmojiSource.Twitter]: '408',
+	[EmojiSource.WhatsApp]: '401'
 } as const satisfies Record<EmojiSource, string>;
 
 export interface DiscordEmoji {

--- a/src/locales/en-US/commands/emoji.json
+++ b/src/locales/en-US/commands/emoji.json
@@ -9,6 +9,7 @@
 	"optionsVariantFacebook": "Facebook",
 	"optionsVariantGoogle": "Google",
 	"optionsVariantMicrosoft": "Microsoft",
+	"optionsVariantMicrosoftFluent": "Microsoft 3D Fluent",
 	"optionsVariantSamsung": "Samsung",
 	"optionsVariantTwitter": "Twitter",
 	"optionsVariantWhatsApp": "WhatsApp",


### PR DESCRIPTION
Comparison, before vs now:
| Apple | Facebook | Google | Microsoft | Microsoft Fluent | Samsung | Twitter | WhatsApp |
| :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
| ![image](https://github.com/user-attachments/assets/7092e217-8278-4573-b0d8-993c329b1b72) | ![image](https://github.com/user-attachments/assets/62792322-17c3-4851-879a-e336ae801199) | ![image](https://github.com/user-attachments/assets/6d76a50f-2b25-41cf-9a0f-9c7232e3dba5) | ![image](https://github.com/user-attachments/assets/e1dcd005-1b0d-4f60-8aad-861cba7f4c9c) | N/A | ![image](https://github.com/user-attachments/assets/63a46801-00e2-4af3-a101-1219bb0ae2f5) | ![image](https://github.com/user-attachments/assets/50a6d246-40bb-4365-9693-06622825166a) | ![image](https://github.com/user-attachments/assets/8e86b358-1194-4d27-aee2-d7964066b744) |
| ![image](https://github.com/user-attachments/assets/d9588f6a-37e5-448a-b48f-ae0b621fcdd5) | ![image](https://github.com/user-attachments/assets/b435b106-9eef-4b90-9d52-4a681ecb3dbe) | ![image](https://github.com/user-attachments/assets/47286e1b-a64f-4d2a-873c-d66f3a8e2266) | ![image](https://github.com/user-attachments/assets/96816325-9604-4e90-a26c-53d52a705163) | ![image](https://github.com/user-attachments/assets/f194da4e-58c3-41b3-9c1e-3e1b02f9986e) | ![image](https://github.com/user-attachments/assets/155f3149-aad5-4966-9214-a9051614bbf3) | ![image](https://github.com/user-attachments/assets/b223dca5-228b-43ea-80aa-8e648d856f2e) | ![image](https://github.com/user-attachments/assets/b2572ea9-09f4-4018-a4f8-667087dd24c3) |